### PR TITLE
Add 'new' to password reset page

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Release 1.4
  * Make tables on account manager pages searchable.
  * Update account manager UI with similar style to portal
-
+ * Add 'new' to password reset page (#104)
 
 Release 1.3
 

--- a/www/reset.html
+++ b/www/reset.html
@@ -40,7 +40,7 @@ span.required {color:red;}
     <p><label class="input">New Password:<span class="required">*</span>
         <input name="password1" type="password" size="50" required
                onchange="form.password2.pattern = this.value;"></label></p>
-    <p><label class="input">Confirm new password:<span class="required">*</span>
+    <p><label class="input">Confirm New password:<span class="required">*</span>
         <input name="password2" type="password" size="50" required
                title="The passwords must match"></label></p>
     <input type="hidden" name="pwchange" value="pwchange"/>

--- a/www/reset.html
+++ b/www/reset.html
@@ -37,10 +37,10 @@ span.required {color:red;}
     <p><label class="input">Username:<span class="required">*</span>
         <input name="username" size="50" required maxlength="8">
       </label>(max. 8 chars, lowercase letters and numbers only)</p>
-    <p><label class="input">Password:<span class="required">*</span>
+    <p><label class="input">New Password:<span class="required">*</span>
         <input name="password1" type="password" size="50" required
                onchange="form.password2.pattern = this.value;"></label></p>
-    <p><label class="input">Confirm password:<span class="required">*</span>
+    <p><label class="input">Confirm new password:<span class="required">*</span>
         <input name="password2" type="password" size="50" required
                title="The passwords must match"></label></p>
     <input type="hidden" name="pwchange" value="pwchange"/>


### PR DESCRIPTION
Clarify that the password entry boxes on the password reset page are
for the new password, not the existing password.

Fixes #104 
