### PR TITLE
Fix blank screen after adding a note

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Release 1.4
  * Make tables on account manager pages searchable.
  * Update account manager UI with similar style to portal
+ * Fix redirect after adding a note (#85)
  * Allow for apostrophes in notes (#94)
  * Make default account request action nothing (#100)
  * Add 'new' to password reset page (#104)

--- a/protected/add_note.php
+++ b/protected/add_note.php
@@ -51,7 +51,12 @@ if ($result['code'] != 0) {
   header("Location: " . $acct_manager_url . "/display_requests.php#leads");
 } elseif ($state==="EMAILED_REQUESTER") {
   header("Location: " . $acct_manager_url . "/display_requests.php#requester");
+} elseif ($state === "CONFIRM_REQUESTER") {
+  header("Location: " . $acct_manager_url . "/display_requests.php#requesterconfirmationdiv");
+} else {
+  header("Location: " . $acct_manager_url . "/display_requests.php");
 }
+
 //log the note
 $res = add_log_with_comment($uid, "Note",$note);
 if ($res != 0) {


### PR DESCRIPTION
After adding a note to a request waiting for confirmation, redirect to
the "waiting for confirmation" group instead of leaving a blank
screen. Also add a default case to redirect to the account requests if
no other case applies after adding a note to avoid blank screens.

Fixes #85
