### PR TITLE
Update join project link in email

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Release 1.4
  * Make default account request action nothing (#100)
  * Add 'new' to password reset page (#104)
  * Do not reissue deleted accounts (#106)
+ * Update the information link in the notification email (#110)
 
 Release 1.3
 

--- a/etc/notification-email.txt
+++ b/etc/notification-email.txt
@@ -18,7 +18,7 @@ You can use your account to access the GENI Portal, please give it a try.
 9. You're done! You should now be at the portal home page.
 
 At this point, you will need to become a member of a project.  To do this, continue with the instructions found here: 
-http://groups.geni.net/geni/wiki/SignMeUp#a2.BecomeamemberofaGENIProject
+http://groups.geni.net/geni/wiki/JoinAProject
 
 If you have any problems, questions, or suggestions for improvement, please contact help@geni.net.
 


### PR DESCRIPTION
In the notification email update the link to more information about
joining a project. The link has changed.

Fixes #110
