### PR TITLE
Stop requiring a non-existent file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # GENI Account Request System Release Notes
 
+# [Release 1.5.1](https://github.com/GENI-NSF/geni-ar/milestones/1.5.1)
+
+* Stop requiring a non-existent file
+  ([#133](https://github.com/GENI-NSF/geni-ar/issues/133))
+
 # [Release 1.5](https://github.com/GENI-NSF/geni-ar/milestones/1.5)
 
 * Handle international characters via UTF8 encoding

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([geni-ar], [1.5], [help@geni.net])
+AC_INIT([geni-ar], [1.5.1], [help@geni.net])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 AM_MAINTAINER_MODE([enable])
 AC_PROG_MKDIR_P

--- a/www/confirmemail.php
+++ b/www/confirmemail.php
@@ -24,7 +24,6 @@
 
 require_once('db_utils.php');
 include_once('/etc/geni-ar/settings.php');
-require_once('institutions.php');
 require_once('ar_constants.php');
 require_once('log_actions.php');
 require_once('email_utils.php');

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -26,7 +26,6 @@ require_once('ldap_utils.php');
 require_once('response_format.php');
 require_once('ssha.php');
 require_once('ar_constants.php');
-require_once('institutions.php');
 include_once('/etc/geni-ar/settings.php');
 
 // Generate a random string (nums, uppercase, lowercase) of width $width


### PR DESCRIPTION
Fix a bug where new account requests fail because the handler is
requiring a non-existing institutions file
