### PR TITLE
Standardize HTML header tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 1.6](https://github.com/GENI-NSF/geni-ar/milestones/1.6)
 
+* Standardize HTML headers, declare UTF-8 charset
+  ([#135](https://github.com/GENI-NSF/geni-ar/issues/135))
 
 # [Release 1.5.1](https://github.com/GENI-NSF/geni-ar/milestones/1.5.1)
 

--- a/Makefile.sync
+++ b/Makefile.sync
@@ -12,10 +12,13 @@ RSYNC_DELETE = --delete --delete-excluded
 RSYNC_ARGS = -aztv $(RSYNC_EXCLUDE)
 
 
-.PHONY: syncb syncd syncm synci syncs synct syncp syncc
+.PHONY: synce syncm
 
 default:
 	echo "Choose a specific sync target."
 
 syncm: 
 	$(RSYNC) $(RSYNC_ARGS) ../geni-ar macomb.gpolab.bbn.com:
+
+synce:
+	$(RSYNC) $(RSYNC_ARGS) ../geni-ar escobar.gpolab.bbn.com:

--- a/protected/approve.php
+++ b/protected/approve.php
@@ -144,8 +144,9 @@ function print_error($message) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Reset Password</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="geni-ar.css" rel="Stylesheet"/>

--- a/protected/whitelist.php
+++ b/protected/whitelist.php
@@ -91,8 +91,9 @@ function print_whitelist() {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI IDP Whitelist</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="geni-ar.css" rel="Stylesheet"/>

--- a/www/confirmemail.php
+++ b/www/confirmemail.php
@@ -250,8 +250,9 @@ function send_admin_confirmation_email($user_email) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Confirm Email</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="kmtool.css" rel="Stylesheet"/>

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -268,8 +268,9 @@ foreach ($optional_vars as $name) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Request an account</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="kmtool.css" rel="Stylesheet"/>

--- a/www/newpasswd.php
+++ b/www/newpasswd.php
@@ -163,8 +163,9 @@ function send_admin_email($email) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Reset Password</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="kmtool.css" rel="Stylesheet"/>

--- a/www/pwchange.php
+++ b/www/pwchange.php
@@ -101,8 +101,9 @@ function send_passwd_change_email($user_email, $change_url) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Reset Password</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="kmtool.css" rel="Stylesheet"/>

--- a/www/usernamerecover.php
+++ b/www/usernamerecover.php
@@ -64,8 +64,9 @@ function send_username_recover_email($user_email, $username) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>GENI: Recover Username</title>
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
 <link type="text/css" href="kmtool.css" rel="Stylesheet"/>


### PR DESCRIPTION
Always declare language ("en") and charset ("utf-8") in HTML headers.

Fixes #135 
