### PR TITLE
Reduce number of admin emails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 1.7](https://github.com/GENI-NSF/geni-ar/milestones/1.7)
 
+* Reduce number of admin emails
+  ([#138](https://github.com/GENI-NSF/geni-ar/issues/138))
 
 # [Release 1.6](https://github.com/GENI-NSF/geni-ar/milestones/1.6)
 

--- a/www/newpasswd.php
+++ b/www/newpasswd.php
@@ -151,13 +151,8 @@ function change_passwd() {
 // Alert admins that request has been successfully completed.
 // This should probabably be removed after new auto confirmation system deemed working
 function send_admin_email($email) {
-  global $AR_EMAIL_HEADERS, $idp_approval_email, $acct_manager_url;
-  $server_host = $_SERVER['SERVER_NAME'];
-  $subject = "New GENI Identity Provider Password Change on $server_host";
-  $body = "User with email $email successfully changed their password on host ";
-  $body .= "$server_host.\n\n";
-  $headers = $AR_EMAIL_HEADERS;
-  mail($idp_approval_email, $subject, $body, $headers);
+    // do nothing, the feature works.
+    // Leaving this as a stub for now -- February 5, 2016
 }
 
 ?>

--- a/www/pwchange.php
+++ b/www/pwchange.php
@@ -94,7 +94,6 @@ function send_passwd_change_email($user_email, $change_url) {
           . "Thank you,\n"
           . "GENI Operations\n";
     $headers = $AR_EMAIL_HEADERS;
-    $headers .= "Cc: $idp_approval_email";
     mail($user_email, $subject, $body, $headers);
 }
 

--- a/www/usernamerecover.php
+++ b/www/usernamerecover.php
@@ -57,7 +57,6 @@ function send_username_recover_email($user_email, $username) {
            . "Thank you,\n"
            . "GENI Operations\n";
     $headers = $AR_EMAIL_HEADERS;
-    $headers .= "Cc: $idp_approval_email";
     mail($user_email, $subject, $body, $headers);
 }
 


### PR DESCRIPTION
Stop sending email to admins on password changes and username
recovery. These new automated features are working and there is no
longer a need to track them.

Fixes #138 
