### PR TITLE
Notice pending requests in an email-confirmed state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Reduce number of admin emails
   ([#138](https://github.com/GENI-NSF/geni-ar/issues/138))
+* Notice pending requests in an email-confirmed state
+  ([#141](https://github.com/GENI-NSF/geni-ar/issues/141))
 
 # [Release 1.6](https://github.com/GENI-NSF/geni-ar/milestones/1.6)
 

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -161,6 +161,7 @@ if (count($result['value']) != 0) {
     if (   $state === "REQUESTED"
         or $state === "EMAILED_LEADS"
         or $state === "CONFIRM_REQUESTER"
+        or $state === "EMAIL_CONFIRMED"
         or $state === "DELETED") {
       $errors[] = "Username " . $uid . " already exists";
     }
@@ -203,7 +204,11 @@ if ($result['code'] != 0) {
 if (count($result['value']) != 0) {
   foreach ($result['value'] as $row) {
     $state = $row['request_state'];
-    if ($state === "REQUESTED" or $state=== "EMAILED_LEADS" or $state=== "EMAILED_REQUESTER") {
+    if (   $state === "REQUESTED"
+        or $state === "EMAILED_LEADS"
+        or $state === "CONFIRM_REQUESTER"
+        or $state === "EMAILED_REQUESTER"
+        or $state === "EMAIL_CONFIRMED") {
       $errors[] = "An account request for this email address is pending approval";
     }
   }


### PR DESCRIPTION
When checking for duplicates add the "email confirmed" state to the
detection block to fix a bug where a duplicate request could be
entered when an identical user id or email address was already in the
email confirmed state.

Fixes #141
