### PR TITLE
Updates for RPM packaging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,7 @@
-AC_INIT([geni-ar], [1.8], [help@geni.net])
+# Specify package name, version, bug report URL, tar name, and URL
+AC_INIT([GENI Account Request], [1.8],
+        [https://github.com/GENI-NSF/geni-ar/issues], [geni-ar],
+	[https://github.com/GENI-NSF/geni-ar])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 AM_MAINTAINER_MODE([enable])
 AC_PROG_MKDIR_P

--- a/geni-ar.spec
+++ b/geni-ar.spec
@@ -7,6 +7,7 @@ License:        GENI Public License
 URL:            https://github.com/GENI-NSF/geni-ar
 Source:         %{name}-%{version}.tar.gz
 Group:          Applications/Internet
+BuildRequires:  texinfo
 Requires:       httpd, postgresql
 
 %description
@@ -24,12 +25,14 @@ make %{?_smp_mflags}
 %install
 rm -rf $RPM_BUILD_ROOT
 %make_install
+rm -f $RPM_BUILD_ROOT%{_infodir}/dir
 
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root)
+%doc %{_infodir}/geni-ar.info.gz
 %{_bindir}/geni-add-log
 %{_bindir}/geni-convert-logs
 %{_datadir}/%{name}/apache2.conf


### PR DESCRIPTION
Update `configure.ac` to include GitHub URLs. Update `geni-ar.spec` to include new info files (i.e. documentation)
