### PR TITLE
Tkt147: looking up account requests by email is problematic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
+* When a requester confirms their email address, we look up
+  the requests that are awaiting confirmation and then use
+  that request ID for later operations.
+  In the process, use various constants more, fix
+  some log messages, add some comments, and add some error
+  logs to note when reading account logs by username results
+  in potential confusion.
+  ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))
 * Removed `Current Reqs` tab; default is `Email Confirmed`.
   Added an EMAIL_CONFIRMED state constant, and make more use
   of constants. New requests change to state `CONFIRM`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,18 +2,11 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
-* When a requester confirms their email address, we look up
-  the requests that are awaiting confirmation and then use
-  that request ID for later operations.
-  In the process, use various constants more, fix
-  some log messages, add some comments, and add some error
-  logs to note when reading account logs by username results
-  in potential confusion.
+* Look up the correct account request when email address is
+  confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))
-* Removed `Current Reqs` tab; default is `Email Confirmed`.
-  Added an EMAIL_CONFIRMED state constant, and make more use
-  of constants. New requests change to state `CONFIRM`
-  once the automatic email to confirm their address is sent.
+* Removed `Current Reqs` tab; requests pending confirmation
+  are on Waiting for Confirmation tab.
   ([#148](https://github.com/GENI-NSF/geni-ar/issues/148))
 * Add initial system documentation
   ([#152](https://github.com/GENI-NSF/geni-ar/issues/152))

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,7 +99,7 @@ dist_bin_SCRIPTS = \
 	bin/geni-add-log \
 	bin/geni-convert-logs
 
-pkgsysconfdir = $(sysconfdir)/$(PACKAGE_NAME)
+pkgsysconfdir = $(sysconfdir)/$(PACKAGE)
 
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(pkgsysconfdir)

--- a/lib/php/db_utils.php
+++ b/lib/php/db_utils.php
@@ -157,6 +157,9 @@ function db_fetch_row($query, $msg = "")
   if (is_int($nr) && $nr == 0) {
     return generate_database_response($code, null, null);
   } else {
+    if (is_int($nr) && $nr > 1) {
+      error_log("db_fetch_row returning 1st of $nr rows for query: $query");
+    }
     $row = $resultset->fetchRow(MDB2_FETCHMODE_ASSOC);
     //print "result has " . count($row) . " rows<br/>\n";
     if (! isset($row) || count($row) == 0) {

--- a/lib/php/db_utils.php
+++ b/lib/php/db_utils.php
@@ -158,7 +158,7 @@ function db_fetch_row($query, $msg = "")
     return generate_database_response($code, null, null);
   } else {
     if (is_int($nr) && $nr > 1) {
-      error_log("db_fetch_row returning 1st of $nr rows for query: $query");
+      error_log("Warning: db_fetch_row Expected 1 row, returning 1st of $nr rows for query: $query");
     }
     $row = $resultset->fetchRow(MDB2_FETCHMODE_ASSOC);
     //print "result has " . count($row) . " rows<br/>\n";

--- a/lib/php/log_actions.php
+++ b/lib/php/log_actions.php
@@ -71,6 +71,13 @@ function add_log_with_comment($uid, $action, $comment)
 
 function create_log($query_vars,$query_values)
 {
+  // FIXME
+  // Note that we log things by uid (username).
+  // handlerequest et al ensure that there's only 1 request with this username
+  // that is approved or pending. But there could be a DENIED request with same username.
+  // We could store the request ID not just the username, to ensure logs are associated with the proper request
+  // For example, manually do CONFIRM REQUESTER on a request, then deny it, then open a new request with same username
+  // - logs will get mixed up
   $sql = "INSERT INTO idp_account_actions ("; 
   $sql .= implode (',',$query_vars);
   $sql .= ') VALUES (';
@@ -89,6 +96,13 @@ function create_log($query_vars,$query_values)
 
 function add_log_comment($uid, $log, $comment)
 {
+  // FIXME
+  // Note that we log things by uid (username).
+  // handlerequest et al ensure that there's only 1 request with this username
+  // that is approved or pending. But there could be a DENIED request with same username.
+  // We could store the request ID not just the username, to ensure logs are associated with the proper request
+  // For example, manually do CONFIRM REQUESTER on a request, then deny it, then open a new request with same username
+  // - logs will get mixed up
   $sql = "SELECT id from idp_account_actions where uid = '" . $uid . "' and action_performed = '" . $log . "' ORDER BY id desc";
   $result = db_fetch_rows($sql);
   $rows = $result['value'];

--- a/protected/acct_actions.php
+++ b/protected/acct_actions.php
@@ -84,7 +84,7 @@ if ($action === "delete") {
       } 
     }
   } else {
-    add_log_comment($uid, "Account Deleted", "FAILED");
+    add_log_comment($id, "Account Deleted", "FAILED");
     process_error( "Failed to delete account for " . $id);
     exit();
   }

--- a/protected/acct_actions.php
+++ b/protected/acct_actions.php
@@ -65,7 +65,7 @@ if ($action === "delete") {
     //change status in postgres database
     if (array_key_exists('uidNumber',$attrs)) {
       if (count($accts) != 1) {
-	error_log("Found " . count($accts) . " accounts in LDAP for uid " . $id);
+	error_log("acct_actions DELETE: Found (deleted) " . count($accts) . " accounts in LDAP for uid " . $id);
       }
       $acct = $accts[0];
       $req_id = $acct['uidnumber'][0];

--- a/protected/acct_actions.php
+++ b/protected/acct_actions.php
@@ -42,6 +42,7 @@ if ($action === "delete") {
   }
 
   // Delete account
+  // FIXME: Log the delete before doing it?
   $res = add_log($id,"Account Deleted");
   if ($res != 0) {
     process_error ("ERROR: Logging failed.  Will not delete account");
@@ -63,6 +64,9 @@ if ($action === "delete") {
 
     //change status in postgres database
     if (array_key_exists('uidNumber',$attrs)) {
+      if (count($accts) != 1) {
+	error_log("Found " . count($accts) . " accounts in LDAP for uid " . $id);
+      }
       $acct = $accts[0];
       $req_id = $acct['uidnumber'][0];
       $sql = "UPDATE " . $AR_TABLENAME . " SET request_state='" . AR_STATE::DELETED . "' WHERE id='" . $req_id . '\'';
@@ -72,7 +76,7 @@ if ($action === "delete") {
 	exit();
       }
 
-      if ($result['value'] === 1) {
+      if ($result[RESPONSE_ARGUMENT::VALUE] === 1) {
 	header("Location: " . $acct_manager_url . "/display_accounts.php");
       } else {
 	process_error("Failed to change request state for deleted account for " . $id);

--- a/protected/action_log.php
+++ b/protected/action_log.php
@@ -25,6 +25,7 @@ include_once('/etc/geni-ar/settings.php');
 require_once('ldap_utils.php');
 require_once('db_utils.php');
 require_once('ar_constants.php');
+require_once('response_format.php');
 
 global $acct_manager_url;
 
@@ -39,14 +40,14 @@ if ($user === "ALL")
     $sql = "SELECT * FROM idp_account_actions where uid='" . $user . '\' order by action_ts desc';
   }
 $result = db_fetch_rows($sql);
-if ($result['code'] != 0) {
+if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   print '<a href="' . $acct_manager_url . '">Return to main page</a>';
   print '<br></br>';
   process_error("Postgres database query failed");
   exit();
 }
 
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 function get_values($row)
 {

--- a/protected/action_log.php
+++ b/protected/action_log.php
@@ -16,7 +16,7 @@
 // OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,ldapsearch -xLLL -b "dc=shib-idp2,dc=gpolab,dc=bbn,dc=com" uid=* sn givenName cn
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
 // IN THE WORK.
@@ -30,6 +30,9 @@ require_once('response_format.php');
 global $acct_manager_url;
 
 $user = $_GET["uid"];
+
+// Show all account logs for the given username (or ALL)
+// Note: account logs are by username. So a previously denied account under the same username will show up here
 
 $conn = db_conn();
 if ($user === "ALL")

--- a/protected/approve.php
+++ b/protected/approve.php
@@ -35,6 +35,7 @@ function accept_user($id) {
       . " and (request_state='" . AR_STATE::EMAIL_CONF . "')";
     $db_result = db_fetch_rows($sql, "fetch accounts with id $id");
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+        // FIXME: Could this return 0 rows?
         $result = $db_result[RESPONSE_ARGUMENT::VALUE][0];
     } else {
         error_log("Error getting user record: " . $db_result[RESPONSE_ARGUMENT::OUTPUT]);

--- a/protected/display_accounts.php
+++ b/protected/display_accounts.php
@@ -130,9 +130,6 @@ foreach ($rows as $row) {
 
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      error_log("Displaying Deleted account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_accounts.php
+++ b/protected/display_accounts.php
@@ -130,9 +130,9 @@ foreach ($rows as $row) {
 
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    if (count($logs) > 1) {
-      error_log("Display deleted account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
-    }
+    //    if (count($logs) > 1) {
+    //      error_log("Displaying Deleted account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_accounts.php
+++ b/protected/display_accounts.php
@@ -118,6 +118,9 @@ foreach ($rows as $row) {
   $org = $row['organization'];
   $performer="";
   $action_ts="";
+  // FIXME: If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. That may not be correct.
+  // We could avoid this by including the request_id in idp_account_actions
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Account Deleted' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
   if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
@@ -127,6 +130,9 @@ foreach ($rows as $row) {
 
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
+    if (count($logs) > 1) {
+      error_log("Display deleted account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_accounts.php
+++ b/protected/display_accounts.php
@@ -100,7 +100,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   exit();
 }
 
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 
 print '<div class="card" id="deleted">';
@@ -125,7 +125,7 @@ foreach ($rows as $row) {
     exit();
   }
 
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -171,10 +171,10 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    if (count($logs) > 1) {
-      // Note that for old accounts where we request confirmation manually this could be legit
-      error_log("Displaying Requested confirmation account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    }
+    //    if (count($logs) > 1) {
+    //      // Note that for old accounts where we request confirmation manually this could be legit
+    //      error_log("Displaying Requested confirmation account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -235,10 +235,10 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    if (count($logs) > 1) {
-      // Note this is legit if we emailed the leads about the same person multiple times
-      error_log("Displaying Emailed leads account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    }
+    //    if (count($logs) > 1) {
+    //      // Note this is legit if we emailed the leads about the same person multiple times
+    //      error_log("Displaying Emailed leads account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -299,10 +299,10 @@ foreach ($rows as $row) {
   }
 
   if ($logs) {
-    if (count($logs) > 1) {
-      // Note this is legit if we emailed the same person multiple times
-      error_log("Displaying Emailed Requester account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    }
+    //    if (count($logs) > 1) {
+    //      // Note this is legit if we emailed the same person multiple times
+    //      error_log("Displaying Emailed Requester account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -429,9 +429,9 @@ foreach ($rows as $row) {
   $action_result = db_fetch_rows($sql);
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    if (count($logs) > 1) {
-      error_log("Displaying Denied account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    }
+    //    if (count($logs) > 1) {
+    //      error_log("Displaying Denied account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -171,10 +171,6 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      // Note that for old accounts where we request confirmation manually this could be legit
-    //      error_log("Displaying Requested confirmation account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -235,10 +231,6 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      // Note this is legit if we emailed the leads about the same person multiple times
-    //      error_log("Displaying Emailed leads account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -299,10 +291,6 @@ foreach ($rows as $row) {
   }
 
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      // Note this is legit if we emailed the same person multiple times
-    //      error_log("Displaying Emailed Requester account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -379,9 +367,6 @@ foreach ($rows as $row) {
 
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      error_log("Displaying Approved account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -429,9 +414,6 @@ foreach ($rows as $row) {
   $action_result = db_fetch_rows($sql);
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-    //    if (count($logs) > 1) {
-    //      error_log("Displaying Denied account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
-    //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -160,6 +160,9 @@ $rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 foreach ($rows as $row) {
   get_values($row);
+  // FIXME: If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. That may not be correct.
+  // We could avoid this by including the request_id in idp_account_actions
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Requested Confirmation' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
   if ($action_result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
@@ -168,6 +171,10 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
+    if (count($logs) > 1) {
+      // Note that for old accounts where we request confirmation manually this could be legit
+      error_log("Display Requested confirmation account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -217,6 +224,9 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
 $rows = $result[RESPONSE_ARGUMENT::VALUE];
 foreach ($rows as $row) {
   get_values($row);
+  // FIXME: If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. That may not be correct.
+  // We could avoid this by including the request_id in idp_account_actions
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Emailed Leads' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
   if ($action_result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
@@ -225,6 +235,10 @@ foreach ($rows as $row) {
   }
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
+    if (count($logs) > 1) {
+      // Note this is legit if we emailed the leads about the same person multiple times
+      error_log("Display Emailed leads account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -273,6 +287,9 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
 $rows = $result[RESPONSE_ARGUMENT::VALUE];
 foreach ($rows as $row) {
   get_values($row);
+  // FIXME: If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. That may not be correct.
+  // We could avoid this by including the request_id in idp_account_actions
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Emailed Requester' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
@@ -282,6 +299,10 @@ foreach ($rows as $row) {
   }
 
   if ($logs) {
+    if (count($logs) > 1) {
+      // Note this is legit if we emailed the same person multiple times
+      error_log("Display Emailed Requester account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);
@@ -338,6 +359,10 @@ foreach ($rows as $row) {
 }
 foreach ($rows as $row) {
   get_values($row);
+  // If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. 
+  // We could avoid this by including the request_id in idp_account_actions
+  // In this case that should be right - the single approved account with this username
   $sql = ("SELECT performer, action_ts from idp_account_actions"
           . " WHERE uid=" . $conn->quote($uname, "text")
           . "       AND (action_performed = "
@@ -354,9 +379,12 @@ foreach ($rows as $row) {
 
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
-  $performer = $logs[0]['performer'];
-  $action_ts = $logs[0]['action_ts'];
-  $action_ts = substr($action_ts,0,16);
+    //    if (count($logs) > 1) {
+    //      error_log("Display Approved account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    //    }
+    $performer = $logs[0]['performer'];
+    $action_ts = $logs[0]['action_ts'];
+    $action_ts = substr($action_ts,0,16);
   } else {
     $performer = '&nbsp;';
     $action_ts = '&nbsp;';
@@ -394,10 +422,16 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
 
 foreach ($rows as $row) {
   get_values($row);
+  // FIXME: If there are multiple accounts with same username and this action,
+  // then here we take only the most recent. That may not be correct.
+  // We could avoid this by including the request_id in idp_account_actions
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Account Denied' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
+    if (count($logs) > 1) {
+      error_log("Display Denied account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
     $action_ts = substr($action_ts,0,16);

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -173,7 +173,7 @@ foreach ($rows as $row) {
   if ($logs) {
     if (count($logs) > 1) {
       // Note that for old accounts where we request confirmation manually this could be legit
-      error_log("Display Requested confirmation account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+      error_log("Displaying Requested confirmation account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
     }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -237,7 +237,7 @@ foreach ($rows as $row) {
   if ($logs) {
     if (count($logs) > 1) {
       // Note this is legit if we emailed the leads about the same person multiple times
-      error_log("Display Emailed leads account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+      error_log("Displaying Emailed leads account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
     }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -301,7 +301,7 @@ foreach ($rows as $row) {
   if ($logs) {
     if (count($logs) > 1) {
       // Note this is legit if we emailed the same person multiple times
-      error_log("Display Emailed Requester account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+      error_log("Displaying Emailed Requester account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
     }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -380,7 +380,7 @@ foreach ($rows as $row) {
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     //    if (count($logs) > 1) {
-    //      error_log("Display Approved account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+    //      error_log("Displaying Approved account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
     //    }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -430,7 +430,7 @@ foreach ($rows as $row) {
   $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     if (count($logs) > 1) {
-      error_log("Display Denied account logs for $uname for " . count($logs) . " performer/timestamps. Using only most recent.");
+      error_log("Displaying Denied account logs for $uname found " . count($logs) . " performer/timestamps. Using only most recent.");
     }
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -109,7 +109,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Query failed to postgres database");
   exit();
 }
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 
 foreach ($rows as $row) {
@@ -156,7 +156,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Postgres database query failed");
   exit();
 }
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 foreach ($rows as $row) {
   get_values($row);
@@ -166,7 +166,7 @@ foreach ($rows as $row) {
     process_error("Postgres database query failed");
     exit();
   }
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -214,7 +214,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Postgres database query failed");
   exit();
 }
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 foreach ($rows as $row) {
   get_values($row);
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Emailed Leads' ORDER BY id desc";
@@ -223,7 +223,7 @@ foreach ($rows as $row) {
     process_error("Postgres database query failed");
     exit();
   }
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];
@@ -270,12 +270,12 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Postgres database query failed");
   exit();
 }
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 foreach ($rows as $row) {
   get_values($row);
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Emailed Requester' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($action_result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
     process_error("Postgres database query failed");
     exit();
@@ -324,7 +324,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Postgres database query failed");
   exit();
 }
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 
 // if created_ts is empty (historic entries), then move to the bottom of the list
 foreach ($rows as $row) {
@@ -352,7 +352,7 @@ foreach ($rows as $row) {
     exit();
   }
 
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
   $performer = $logs[0]['performer'];
   $action_ts = $logs[0]['action_ts'];
@@ -386,7 +386,7 @@ foreach ($rows as $row) {
 $sql = "SELECT * FROM " . $AR_TABLENAME . " WHERE request_state='" . AR_STATE::DENIED . '\'';
 $result = db_fetch_rows($sql);
 
-$rows = $result['value'];
+$rows = $result[RESPONSE_ARGUMENT::VALUE];
 if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   process_error("Postgres database query failed");
   exit();
@@ -396,7 +396,7 @@ foreach ($rows as $row) {
   get_values($row);
   $sql = "SELECT performer, action_ts from idp_account_actions WHERE uid='" . $uname . "' and action_performed='Account Denied' ORDER BY id desc";
   $action_result = db_fetch_rows($sql);
-  $logs = $action_result['value'];
+  $logs = $action_result[RESPONSE_ARGUMENT::VALUE];
   if ($logs) {
     $performer = $logs[0]['performer'];
     $action_ts = $logs[0]['action_ts'];

--- a/protected/fix_actions.php
+++ b/protected/fix_actions.php
@@ -25,6 +25,7 @@ include_once('/etc/geni-ar/settings.php');
 require_once('ldap_utils.php');
 require_once('db_utils.php');
 require_once('ar_constants.php');
+require_once('response_format.php');
 
 $ldapconn = ldap_setup();
 if ($ldapconn === -1) {
@@ -73,16 +74,16 @@ while( $entry ) {
   //and get the request id
   $sql = "SELECT id from idp_account_request where username_requested='" . $uid . "' order by id desc"; 
   $result = db_fetch_rows($sql);
-  if ($result['code'] != 0) {
+  if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
     print("Postgres database query failed");
     exit();
   }
-  if (count($result['value']) != 0) {
-    $row = $result['value'][0];
+  if (count($result[RESPONSE_ARGUMENT::VALUE]) != 0) {
+    $row = $result[RESPONSE_ARGUMENT::VALUE][0];
     $id = $row['id'];
   } else {
     $conn = db_conn();
-    $values = array($attrs['givenName'],$attrs['sn'],$attrs['mail'],$uid,$attrs['telephoneNumber'],$attrs['userPassword'],$attrs['o'],"HISTORIC","HISTORIC","APPROVED");
+    $values = array($attrs['givenName'],$attrs['sn'],$attrs['mail'],$uid,$attrs['telephoneNumber'],$attrs['userPassword'],$attrs['o'],"HISTORIC","HISTORIC",AR_STATE::APPROVED);
     $query_vals = array();
     foreach ($values as $val) {
       $query_vals[] = $conn->quote($val,"text");
@@ -108,11 +109,11 @@ while( $entry ) {
     //get request id
     $sql = "SELECT id from idp_account_request where username_requested='" . $uid . "' order by id desc";
     $result = db_fetch_rows($sql);
-    if ($result['code'] != 0) {
+    if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
       print("<p>Postgres database query failed</p>");
       exit();
     }
-    $row = $result['value'][0];
+    $row = $result[RESPONSE_ARGUMENT::VALUE][0];
     $id = $row['id'];
   }
 

--- a/protected/ldap.php
+++ b/protected/ldap.php
@@ -1,4 +1,26 @@
 <?php
+//----------------------------------------------------------------------
+// Copyright (c) 2012-2016 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
 
 // Load from settings
 $ldaprdn  = 'cn=admin,dc=shib-idp2,dc=gpolab,dc=bbn,dc=com';

--- a/protected/request_actions.php
+++ b/protected/request_actions.php
@@ -48,7 +48,7 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   exit();
 }
 
-$row = $result['value'][0];
+$row = $result[RESPONSE_ARGUMENT::VALUE][0];
 
 $uid = $row['username_requested']; 
 

--- a/protected/tutorial_actions.php
+++ b/protected/tutorial_actions.php
@@ -140,7 +140,7 @@ for ($x=1; $x<=intval($num); $x++)
       process_error("Postgres database query failed");
       exit();
     }
-    $row = $result['value'][0];
+    $row = $result[RESPONSE_ARGUMENT::VALUE][0];
     $id = $row['id'];
 
     //Now create ldap accounts

--- a/protected/whitelist.php
+++ b/protected/whitelist.php
@@ -23,6 +23,7 @@
 //----------------------------------------------------------------------
 
 require_once('db_utils.php');
+require_once('response_format.php');
 
 // Insert a new institution into the idp_whitlelist table
 function insert_to_whitelist($institution) {

--- a/protected/whitelist.php
+++ b/protected/whitelist.php
@@ -64,7 +64,7 @@ function delete_from_whitelist($institutions) {
 function print_whitelist() {
     $db_conn = db_conn();
     $sql = "SELECT * from idp_whitelist";
-    $db_result = db_fetch_rows($sql, "insert idp_passwd_reset");
+    $db_result = db_fetch_rows($sql, "read idp_whitelist");
 
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
         $institutions = $db_result[RESPONSE_ARGUMENT::VALUE];

--- a/www/confirmemail.php
+++ b/www/confirmemail.php
@@ -43,6 +43,11 @@ function confirm_email($nonce, $db_id) {
 	}
         $email = $result['email'];
 
+	// Note: We could include the specific request ID as an column in idp_email_confirm,
+	// and use that to ensure we update the correct row here.
+	// However, there can be only 1 account with given email address awaiting
+	// confirmation, so this is not necessary
+
 	// Old style started requests as REQUESTED. Now start as CONFIRM. Cover both,
 	// so when this code is applied accounts awaiting confirmation are covered.
 	// FIXME: Could we do some heuristic on request_ts to ensure we get the right row here?

--- a/www/confirmemail.php
+++ b/www/confirmemail.php
@@ -35,29 +35,35 @@ function confirm_email($nonce, $db_id) {
     . "where id =" . $db_conn->quote($db_id, 'integer')
     . " and nonce =" . $db_conn->quote($nonce, 'text');
     $db_result = db_fetch_row($sql, "get idp_email_confirm");
-
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
         $result = $db_result[RESPONSE_ARGUMENT::VALUE];
+	if (is_null($result)) {
+	  error_log("Found no email confirmation record for id $db_id, nonce $nonce");
+          return array("", null);
+	}
         $email = $result['email'];
 
 	// Old style started requests as REQUESTED. Now start as CONFIRM. Cover both,
 	// so when this code is applied accounts awaiting confirmation are covered.
-        $sql = "UPDATE idp_account_request SET request_state='" . AR_STATE::EMAIL_CONF . "'"
+	// FIXME: Could we do some heuristic on request_ts to ensure we get the right row here?
+        $sql2 = "UPDATE idp_account_request SET request_state='" . AR_STATE::EMAIL_CONF . "'"
              . " where email = " . $db_conn->quote($email, 'text')
-	  . " and (request_state='" . AR_STATE::REQUESTED . "' or request_state='" . AR_STATE::CONFIRM . "')";
-        $update_result = db_execute_statement($sql);
+	  . " and (request_state='" . AR_STATE::REQUESTED . "' or request_state='" . AR_STATE::CONFIRM . "')"
+	  . "RETURNING id";
+        $update_result = db_fetch_row($sql2, "update idp_account_request confirm email");
         if ($update_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
             delete_confirmation($db_id, $nonce);
-            return $email;
+	    $acctreq_id = $update_result[RESPONSE_ARGUMENT::VALUE]['id'];
+	    return array($email, $acctreq_id);
         } else {
             error_log("Failed to update user account status: " .
                       $update_result[RESPONSE_ARGUMENT::OUTPUT]);
-            return $email;
+            return array($email, null);
         }
     } else {
         error_log("Error getting email confirm record: "
                  . $db_result[RESPONSE_ARGUMENT::OUTPUT]);
-        return "";
+        return array("", null);
     }
 }
 
@@ -78,10 +84,13 @@ function check_whitelist($user_email) {
     }
 }
 
-function accept_user($user_email) {
+function accept_user($user_email, $acctreq_id) {
     $db_conn = db_conn();
     $sql = "SELECT * from idp_account_request where email=" . $db_conn->quote($user_email, 'text')
       . " and (request_state='" . AR_STATE::EMAIL_CONF . "')";
+    if (! is_null($acctreq_id)) {
+      $sql = $sql . " and id =" . $db_conn->quote($acctreq_id, 'integer');
+    }
     $db_result = db_fetch_rows($sql, "fetch accounts with that email $user_email");
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
         $result = $db_result[RESPONSE_ARGUMENT::VALUE][0];
@@ -218,7 +227,7 @@ function delete_confirmation($id, $nonce) {
 }
 
 // Email admins about new request
-function send_admin_confirmation_email($user_email) {
+function send_admin_confirmation_email($user_email, $acctreq_id) {
     global $AR_EMAIL_HEADERS, $idp_approval_email, $acct_manager_url;
     $server_host = $_SERVER['SERVER_NAME'];
     $subject = "New GENI Identity Provider Account Request on $server_host";
@@ -228,9 +237,12 @@ function send_admin_confirmation_email($user_email) {
 
     $db_conn = db_conn();
     $sql = "SELECT * from idp_account_request where email=" . $db_conn->quote($user_email, 'text');
+    if (! is_null($acctreq_id)) {
+      $sql = $sql  . " and id = " . $db_conn->quote($acctreq_id, 'integer');
+    }
 
     $db_result = db_fetch_rows($sql, "fetch accounts with that email $user_email");
-    if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+    if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE && ! is_null($db_result[RESPONSE_ARGUMENT::VALUE]) && count($db_result[RESPONSE_ARGUMENT::VALUE]) == 1) {
         $result = $db_result[RESPONSE_ARGUMENT::VALUE][0];
         $email_vars = array('first_name', 'last_name', 'email', 'organization', 'title', 'reason');
         foreach ($email_vars as $var) {
@@ -240,7 +252,7 @@ function send_admin_confirmation_email($user_email) {
         $id = $result['id'];
         $body .= "\nSee $acct_manager_url" . "/approve.php?id=$id to approve this request.\n";
     } else {
-        error_log("Error getting user record: " . $db_result[RESPONSE_ARGUMENT::OUTPUT]);
+        error_log("Error getting user record for email $user_email, reqid $acctreq_id: " . $db_result[RESPONSE_ARGUMENT::OUTPUT]);
     }
 
     $body .= "\nSee $acct_manager_url" . "/display_requests.php to handle this request.\n";
@@ -270,20 +282,20 @@ if (array_key_exists('n', $_REQUEST) && array_key_exists('id', $_REQUEST)) {
     $nonce = $_REQUEST['n'];
     $db_id = $_REQUEST['id'];
 
-    $email = confirm_email($nonce, $db_id);
+    list($email, $acctreq_id) = confirm_email($nonce, $db_id);
 
     if($email != "") {
         if (check_whitelist($email)) {
-            if (accept_user($email)) {
+	  if (accept_user($email, $acctreq_id)) {
                 print "<h2>Account successfully created</h2>";
                 print "<a href='https://portal.geni.net'>Login to GENI</a>";
             } else {
-                send_admin_confirmation_email($email);
+	        send_admin_confirmation_email($email, $acctreq_id);
                 print "<h2>Email address $email successfully confirmed</h2>";
                 print "<p>You should hear from us in a few days regarding the status of your new account.</p>";
             }
         } else {
-            send_admin_confirmation_email($email);
+	    send_admin_confirmation_email($email, $acctreq_id);
             print "<h2>Email address $email successfully confirmed</h2>";
             print "<p>You should hear from us in a few days regarding the status of your new account.</p>";
         }

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -152,7 +152,7 @@ if (array_key_exists('email', $_REQUEST) && $_REQUEST['email']) {
 // Get a database connection so that values can be quoted
 $db_conn = db_conn();
 
-//check if there is a pending request for this username
+// check if there is a pending request for this username
 $sql = "SELECT * from idp_account_request where username_requested = ";
 $sql .= $db_conn->quote($uid, 'text');
 $result = db_fetch_rows($sql);
@@ -161,8 +161,8 @@ if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   error_log("Postgres database query failed");
   exit();
 }
-if (count($result['value']) != 0) {
-  foreach ($result['value'] as $row) {
+if (count($result[RESPONSE_ARGUMENT::VALUE]) != 0) {
+  foreach ($result[RESPONSE_ARGUMENT::VALUE] as $row) {
     $state = $row['request_state'];
     if (   $state === AR_STATE::REQUESTED
 	   or $state === AR_STATE::LEADS
@@ -173,24 +173,24 @@ if (count($result['value']) != 0) {
     }
     if ($state == AR_STATE::REQUESTER) {
       //get the request id
-      $sql = "SELECT id from idp_account_request where username_requested='" . $uid . "' and (request_state='" . AR_STATE::REQUESTER . "')";
-      $result = db_fetch_rows($sql);
-      if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
+      $sql2 = "SELECT id from idp_account_request where username_requested='" . $uid . "' and (request_state='" . AR_STATE::REQUESTER . "')";
+      $result2 = db_fetch_rows($sql2);
+      if ($result2[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
         print("Postgres database query failed");
         error_log("Postgres database query failed");
         exit();
       }
-      if (count($result['value']) === 1) {
-        $id = $result['value'][0]['id'];
+      if (count($result2[RESPONSE_ARGUMENT::VALUE]) === 1) {
+        $id = $result2[RESPONSE_ARGUMENT::VALUE][0]['id'];
       } else {
         print("Error retrieving account");
-        error_log("Error retrieving account");
+        error_log("Error retrieving account request - found " . count($result2[RESPONSE_ARGUMENT::VALUE]) . " rows waiting on requester with username " . $uid);
         exit();
       }
       // deny original request and submit this one
-      $sql = "UPDATE idp_account_request SET request_state='" . AR_STATE::DENIED . "' where id='" . $id . '\'';
-      $result = db_execute_statement($sql);
-      if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
+      $sql3 = "UPDATE idp_account_request SET request_state='" . AR_STATE::DENIED . "' where id='" . $id . '\'';
+      $result3 = db_execute_statement($sql3);
+      if ($result3[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
         print ("Database action failed.  Could not change request status for password change request for" . $uid);
         error_log ("Database action failed.  Could not change request status for password change request for " . $uid);
         exit();
@@ -200,15 +200,15 @@ if (count($result['value']) != 0) {
 }
 
 //check if there is a pending request for this email
-$sql = "SELECT * from idp_account_request where email='" . $email . '\'';
-$result = db_fetch_rows($sql);
-if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
+$sql4 = "SELECT * from idp_account_request where email='" . $email . '\'';
+$result4 = db_fetch_rows($sql4);
+if ($result4[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
   print("Postgres database query failed");
   error_log("Postgres database query failed");
   exit();
 }
-if (count($result['value']) != 0) {
-  foreach ($result['value'] as $row) {
+if (count($result4[RESPONSE_ARGUMENT::VALUE]) != 0) {
+  foreach ($result4[RESPONSE_ARGUMENT::VALUE] as $row) {
     $state = $row['request_state'];
     if (   $state === AR_STATE::REQUESTED
 	   or $state === AR_STATE::LEADS

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -60,6 +60,12 @@ function create_email_confirm_link($base_path, $id1, $id2) {
 
 // Insert the password change request into the idp_email_confirm table
 function insert_email_confirm($email, $nonce) {
+    // Note: We could include the specific request ID as an arg
+    // Then we could use that in insert_email_confirm so that confirmemail.php
+    // has the correct request ID handy (in idp_email_confirm DB table).
+    // However, there can be only 1 account with given email address awaiting
+    // confirmation, so this is not necessary
+
     $db_conn = db_conn();
     $sql = "insert into idp_email_confirm (email, nonce) values (";
     $sql .= $db_conn->quote($email, 'text');
@@ -303,6 +309,12 @@ if ($errors) {
   $sql .= ')';
   $result = db_execute_statement($sql, 'insert idp account request');
 
+  // Note: We could add "returning id" to that clause, to get the specific request ID
+  // Then we could use that in insert_email_confirm so that confirmemail.php
+  // has the correct request ID handy (in idp_email_confirm DB table).
+  // However, there can be only 1 account with given email address awaiting
+  // confirmation, so this is not necessary
+
   // An error occurred. First, log the query and result for debugging
   if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
     error_log("DB Error query: $sql");
@@ -340,10 +352,10 @@ if ($errors) {
 	$email_body = str_replace("'","''",$email_body);
 	$email_body = str_replace("\\","\\\\",$email_body);
 
-	$res = add_log_with_comment($db_id, "Requested Confirmation",$email_body);
+	$res = add_log_with_comment($uid, "Requested Confirmation",$email_body);
 	if ($res != RESPONSE_ERROR::NONE) {
 	  //try again without the comment
-	  $res = add_log($db_id,"Requested Confirmation");
+	  $res = add_log($uid,"Requested Confirmation");
 	  if ($res != RESPONSE_ERROR::NONE) {
 	    error_log("Failed to log email to " . $email . " for account " . $uid);
 	    // Keep going though

--- a/www/newpasswd.php
+++ b/www/newpasswd.php
@@ -134,7 +134,7 @@ function change_passwd() {
                         return true;
                     }
                 } else {
-                    error_log("Error retrieving account");
+		    error_log("Error retrieving account to change password: for email " . $email . " got " . count($result) . " approved requests");
                     return false;
                 }
             }

--- a/www/newpasswd.php
+++ b/www/newpasswd.php
@@ -84,6 +84,9 @@ function change_passwd() {
             $email = validate_passwdchange();
             if($email) {
                 $db_conn = db_conn();
+		// Here we rely on the checks in handle_request to ensure there is only ever 1
+		// account with given email in APPROVED state
+		// (and below we insist count==1)
                 $sql = "SELECT * from idp_account_request where email=" . $db_conn->quote($email, 'text') 
 		  . " and (request_state='" . AR_STATE::APPROVED . "')"; // ??
                 $db_result = db_fetch_rows($sql, "fetch accounts with that email $email");

--- a/www/pwchange.php
+++ b/www/pwchange.php
@@ -141,7 +141,7 @@ if (!array_key_exists($EMAIL_KEY, $_REQUEST)) {
                     $change_url = create_newpasswd_link($_SERVER['PHP_SELF'], $db_id, $nonce);
                     send_passwd_change_email($email, $change_url);
                     print "<h2>An email to reset your password has been sent.</h2>";
-                    print "<p>If this was done by accident, simply ignore the email you receive</p>";
+                    print "<p>If this was done by accident, simply ignore the email you receive.</p>";
                 } else {
                     $error = "Internal Error";  
                 }

--- a/www/usernamerecover.php
+++ b/www/usernamerecover.php
@@ -29,6 +29,7 @@ require_once('ar_constants.php');
 
 // Return username associated with $email, "" if no user found.
 function retrieve_username($email) {
+    // Note we assume at most 1 approved request with a given email address
     $db_conn = db_conn();
     $sql = "SELECT * from idp_account_request where "
          . "email = " . $db_conn->quote($email, "text")


### PR DESCRIPTION
confirmemail now looks up the account request by email AND the request state awaiting confirmation. Then other utilities use the ID of the account request, rather than only using the email address (that was allowing finding an old denied account request e.g. in emailing the admins with details on the new account request).

Also
- fix `Makefile.am` to use `PACKAGE` not `PACKAGE_NAME` to get the `geni-ar` directory name
- add comments
- use constants more
- add some log messages looking for errors

Fixes issue #147 
