### PR TITLE
Tkt149 removeoptions `Confirm Requested` and `Change Passwrd`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 * Remove obsolete options for admin to `CONFIRM REQUESTER`
   or `CHANGE PASSWRD`. These are self service now.
-  ([#149](https://github.com/GENI-NSF/geni-ar/issues/149))
+  ([#149](https://github.com/GENI-NSF/geni-ar/issues/149)), 
+  ([#117](https://github.com/GENI-NSF/geni-ar/issues/117))
 * Look up the correct account request when email address is
   confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
+* Remove obsolete options for admin to `CONFIRM REQUESTER`
+  or `CHANGE PASSWRD`. These are self service now.
+  ([#149](https://github.com/GENI-NSF/geni-ar/issues/149))
 * Look up the correct account request when email address is
   confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))

--- a/lib/php/email_utils.php.in
+++ b/lib/php/email_utils.php.in
@@ -34,7 +34,7 @@ class EMAIL_TEMPLATE {
   const DIRECTORY = "@pkgsysconfdir@";
   const ALT_DIRECTORY = "@pkgdatadir@/etc";
 
-  const CONFIRM = 'confirm-email.txt';
+  const CONFIRM = 'confirm-email.txt'; // Unused (OBE)
   const LEADS = 'leads-email.txt';
   const NOTIFICATION = 'notification-email.txt';
   const TUTORIAL = 'tutorial-email.txt';

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -117,7 +117,7 @@ foreach ($rows as $row) {
   print "<tr>";
   print'<td class="actions">';
   print '<form method="POST" action="request_actions.php">';
-  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="confirm">CONFIRM REQUESTER</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="passwd">CHANGE PASSWRD</option><option value="note">ADD NOTE</option></select>';
+  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="note">ADD NOTE</option></select>';
   print $actions;
   print '<input type="submit" value="SUBMIT" class="actionsubmit" disabled />';
   print "<input type=\"hidden\" name=\"id\" value=\"$id\"/>";
@@ -183,7 +183,7 @@ foreach ($rows as $row) {
   print "<tr>";
   print'<td class="actions">';
   print '<form method="POST" action="request_actions.php">';
-  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="confirm">CONFIRM REQUESTER</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="note">ADD NOTE</option></select>';
+  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="note">ADD NOTE</option></select>';
   print $actions;
   print '<input type="submit" value="SUBMIT" class="actionsubmit" disabled />';
   print "<input type=\"hidden\" name=\"id\" value=\"$id\"/>";
@@ -242,7 +242,7 @@ foreach ($rows as $row) {
   print "<tr>";
   print'<td class="actions">';
   print '<form method="POST" action="request_actions.php">';
-  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="confirm">CONFIRM REQUESTER</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="note">ADD NOTE</option></select>';
+  $actions = '<select class="actionselect" name=action><option disabled selected> -- select an option -- </option><option value="approve">APPROVE</option><option value="deny">DENY</option><option value="leads">EMAIL LEADS</option><option value="requester">EMAIL REQUESTER</option><option value="note">ADD NOTE</option></select>';
   print $actions;
   print '<input type="submit" value="SUBMIT" class="actionsubmit" disabled />';
   print "<input type=\"hidden\" name=\"id\" value=\"$id\"/>";

--- a/protected/request_actions.php
+++ b/protected/request_actions.php
@@ -187,8 +187,8 @@ else if ($action === "leads")
 
     //$replyto = $idp_approval_email . "," . $idp_leads_email;
     $replyto = $idp_approval_email;
-    print '<head><title>Email Leads</title></head>';
-    print '<a href="' . $acct_manager_url . '">Return to main page</a>';
+    print '<html><head><title>Email Leads</title></head>';
+    print '<body><a href="' . $acct_manager_url . '">Return to main page</a>';
     
     print '<form method="POST" action="send_email.php?arstate=' . AR_STATE::LEADS . '">';
     print 'To: <input type="text" name="sendto" value="' . $idp_leads_email . '">';
@@ -201,7 +201,7 @@ else if ($action === "leads")
     print "<input type=\"hidden\" name=\"log\" value=\"Emailed Leads\"/>";
     print "<input type=\"hidden\" name=\"reply\" value=\"$replyto\"/>";
     print '<input type="submit" value="SEND"/>';
-    print "</form>";
+    print "</form></body></html>";
     
   }
 else if ($action === "requester")
@@ -209,8 +209,8 @@ else if ($action === "requester")
     $filetext = EMAIL_TEMPLATE::load(EMAIL_TEMPLATE::USER);
     $filetext = str_replace("REQUESTER",$firstname,$filetext);
     
-    print '<head><title>Email Requester</title></head>';
-    print '<a href="' . $acct_manager_url . '">Return to main page</a>';
+    print '<html><head><title>Email Requester</title></head>';
+    print '<body><a href="' . $acct_manager_url . '">Return to main page</a>';
     
     print '<form method="POST" action="send_email.php?arstate=' . AR_STATE::REQUESTER . '">';
     print 'To: <input type="text" name="sendto" value="' . $user_email . '">';
@@ -223,15 +223,15 @@ else if ($action === "requester")
     print "<input type=\"hidden\" name=\"log\" value=\"Emailed Requester\"/>";
     print "<input type=\"hidden\" name=\"reply\" value=\"$idp_approval_email\"/>";
     print '<input type="submit" value="SEND"/>';
-    print "</form>";
+    print "</form></body></html>";
     
   } 
 else if ($action === "note") 
   {
     $oldnote = $row['notes'];
     $state = $row['request_state'];
-    print '<head><title>Email Requester</title></head>';
-    print '<a href="' . $acct_manager_url . '/display_requests.php">Return to Account Requests</a>';
+    print '<html><head><title>Email Requester</title></head>';
+    print '<body><a href="' . $acct_manager_url . '/display_requests.php">Return to Account Requests</a>';
     print '<br><br>';
     print '<form method="POST" action="add_note.php">';
     print '<textarea name="note" rows="8" cols="40"></textarea>';
@@ -245,17 +245,24 @@ else if ($action === "note")
     print '<form method="POST" action="display_requests.php">';
     print '<input type="submit" value="CANCEL"/>';    
     print "</form>";
-  }    
+    print "</body></html>";
+  } else {
+  error_log("Unknown request action '$action'");
+  print "<html><head><title>Request Unknown</title></head>\n";
+  print "<body><h1>Error: Action '$action' unknown</h1>\n";
+  print "</body></html>";
+}
 
 ldap_close($ldapconn);
 
 function process_error($msg)
 {
   global $acct_manager_url;
-
+  print "<html><head><title>Error processing request action</title>";
+  print "<body><h1>";
   print "$msg";
-  print ('<br><br>');
-  print ('<a href="' . $acct_manager_url . '/display_requests.php">Return to Account Requests</a>'); 
+  print ('</h1><br/><br/>');
+  print ('<a href="' . $acct_manager_url . '/display_requests.php">Return to Account Requests</a></body></html>');
   error_log($msg);
 }
 ?>


### PR DESCRIPTION
Now that experimenters self service changing their password and confirming their email address, these should not be options on the management pages.

Remove these from the dropdown of actions, and remove the code in request-actions to handle them.

Fixes issue #117 
Fixes issue #149 
