### PR TITLE
Issue #150: Add link to whitelist.php from header.php and index.html

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
+* Add link to page to manage whitelisted domains.
+  ([#150](https://github.com/GENI-NSF/geni-ar/issues/150))
 * Look up the correct account request when email address is
   confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))

--- a/lib/php/header.php
+++ b/lib/php/header.php
@@ -69,6 +69,7 @@ function show_header($title, $table_ids) {
   echo "<body>";
 
   echo "<ul id='header'>";
+  echo "<li class='headerlink'><a href='whitelist.php'>Manage Whitelist</a></li>";
   echo "<li class='headerlink'><a href='tutorial_confirmation.php'>Create Tutorial Accounts</a></li>";
   echo "<li class='headerlink'><a href='action_log.php?uid=ALL'>Account Action Logs</a></li>";
   echo "<li class='headerlink'><a href='display_accounts.php'>Manage Accounts</a></li>";

--- a/protected/index.html
+++ b/protected/index.html
@@ -10,5 +10,6 @@
     <a href="display_accounts.php" >Manage Current Accounts</a><br>
     <a href="action_log.php?uid=ALL" >Account Action Logs</a><br>
     <a href="tutorial_confirmation.php" >Create Tutorial Accounts</a><br>
+    <a href="whitelist.php" >Manage Whitelist</a><br>
   </body>
 </html>

--- a/protected/whitelist.php
+++ b/protected/whitelist.php
@@ -69,7 +69,8 @@ function print_whitelist() {
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
         $institutions = $db_result[RESPONSE_ARGUMENT::VALUE];
         if (count($institutions) > 0) {
-            print "<p>(Check things if you want to delete them)</p>";
+	    print "<p>Listed institutions are whitelisted; users using a confirmed email address from this insitution may use GENI without manual approval.</p>";
+            print "<p>Check a domain to select it for deletion, or add a new institution below.</p>";
             print "<form action='whitelist.php' method='POST'><ul style='list-style-type:none'>";
             $i = 0;
             foreach ($institutions as $inst) {
@@ -89,18 +90,9 @@ function print_whitelist() {
     }
 }
 
+require_once("header.php");
+show_header("GENI IdP Whitelisted Domain Management", array());
 ?>
-
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>GENI IDP Whitelist</title>
-<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css">
-<link type="text/css" href="geni-ar.css" rel="Stylesheet"/>
-<script type='text/javascript' charset='utf8' src='https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js'></script>
-
-</head>
 
 <script type="text/javascript">
     $(document).ready(function(){
@@ -113,10 +105,9 @@ function print_whitelist() {
         });
     });
 </script>
-<body>
 
+<h2  style='margin-top: 80px;' class='card'>Whitelisted Domains</h2>
 <div id="content" class='card' style="width:500px; margin: 30px auto">
-<h2>Whitelist page</h2>
 
 <?php
 


### PR DESCRIPTION
Add link to `whitelist.php` (`Manage Whitelist`) from the header on all pages, and the initial index page.

Use `header.php` on `whitelist.php` so it has look of the other pages. Expand text on that page explaining use of the whitelist page.

Fix issue #150 
