### PR TITLE
Issue #146: Validate request phone number in PHP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
+* Check that phone numbers use only legal characters.
+  ([#146](https://github.com/GENI-NSF/geni-ar/issues/146))
 * Look up the correct account request when email address is
   confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))

--- a/www/handlerequest.php
+++ b/www/handlerequest.php
@@ -251,6 +251,21 @@ if ($p1 === $p2) {
   $errors[] = "Passwords do not match.";
 }
 
+// Check for a phone number that LDAP can handle
+// Here we require the first character be non-space,
+// and otherwise accept all characters the ITU standard E.123 accepts,
+// less those that our LDAP implementation seems to dislike.
+// Note that this allows clearly bogus phone numbers, eg.
+// "+" or "nophone"
+if (array_key_exists('phone', $_REQUEST) && $_REQUEST['phone']) {
+  $phone = $_REQUEST['phone'];
+  $pattern = '/^[\+\(\)0-9a-zA-Z\/\.\-\,]+[\+ \(\)0-9a-zA-Z\/\.\-\,]*$/';
+  $ret = preg_match($pattern, $phone);
+  if ($ret === FALSE || $ret === 0) {
+    $errors[] = "Invalid phone number.";
+  }
+}
+
 $required_vars = array('first_name', 'last_name', 'email', 'username_requested',
                        'phone', 'password_hash', 'organization', 'title', 'reason');
 


### PR DESCRIPTION
Issue #146: Validate request phone number in PHP, requiring they use only characters our LDAP can accept, and start with a non space character.

Using regex `/^[\+\(\)0-9a-zA-Z\/\.\-\,]+[\+ \(\)0-9a-zA-Z\/\.\-\,]*$/`.
Specifically, we disallow things like `#`, `*`, `_`, `$`, `:`, and unicode characters.

Not trying to validate in javascript (Safari honors the HTML5 `tel` input type so is doing something already I believe).

Fixes issue #146 
