### PR TITLE
Issue #140: Sort whitelisted domains by domain name 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 
+* Sort whitelisted institutions.
+  ([#140](https://github.com/GENI-NSF/geni-ar/issues/140))
 * Look up the correct account request when email address is
   confirmed and we email the admins.
   ([#147](https://github.com/GENI-NSF/geni-ar/issues/147))

--- a/protected/whitelist.php
+++ b/protected/whitelist.php
@@ -63,7 +63,7 @@ function delete_from_whitelist($institutions) {
 
 function print_whitelist() {
     $db_conn = db_conn();
-    $sql = "SELECT * from idp_whitelist";
+    $sql = "SELECT * from idp_whitelist ORDER BY institution";
     $db_result = db_fetch_rows($sql, "read idp_whitelist");
 
     if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {


### PR DESCRIPTION
Sort whitelisted domains on `whitelist.php` by the full domain name (`institution` column).

This provides a predictable sort order, though it does not try to group scools, teasing apart top level domains from sub domains for example.

Fix issue #140 
