### PR TITLE
Tkt158: Add an expiration on tutorial accounts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,15 @@
 
 ## Changes
 
-* None
+* Add expiration on tutorial accounts.
+  ([#158](https://github.com/GENI-NSF/geni-ar/issues/158))
 
 ## Installation Notes
 
-* None
+* Add `expiration` column to `idp_account_request`:
+   ```
+   psql -U accreq -h localhost accreq < /usr/share/geni-ar/db/postgresql/update-3.sql
+   ```
 
 # [Release 1.8](https://github.com/GENI-NSF/geni-ar/milestones/1.8)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,8 @@ nobase_dist_pkgdata_DATA = \
 	apache-2.4.conf \
 	db/postgresql/schema.sql \
 	db/postgresql/update-1.sql \
+	db/postgresql/update-2.sql \
+	db/postgresql/update-3.sql \
 	etc/confirm-email.txt \
 	etc/leads-email.txt \
 	etc/notification-email.txt \

--- a/db/postgresql/schema.sql
+++ b/db/postgresql/schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE idp_account_request (
   username_assigned VARCHAR,
   created_ts timestamp DEFAULT NULL,
   request_state VARCHAR DEFAULT 'REQUESTED',
-  notes VARCHAR
+  notes VARCHAR,
+  expiration timestamp DEFAULT NULL
 );
 
 DROP TABLE IF EXISTS idp_account_actions;

--- a/db/postgresql/update-3.sql
+++ b/db/postgresql/update-3.sql
@@ -1,0 +1,3 @@
+-- Add expiration on account requests (and accounts)
+
+ALTER TABLE idp_account_request ADD COLUMN expiration timestamp DEFAULT NULL;

--- a/geni-ar.spec
+++ b/geni-ar.spec
@@ -39,6 +39,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/%{name}/apache-2.4.conf
 %{_datadir}/%{name}/db/postgresql/schema.sql
 %{_datadir}/%{name}/db/postgresql/update-1.sql
+%{_datadir}/%{name}/db/postgresql/update-2.sql
+%{_datadir}/%{name}/db/postgresql/update-3.sql
 %{_datadir}/%{name}/etc/confirm-email.txt
 %{_datadir}/%{name}/etc/leads-email.txt
 %{_datadir}/%{name}/etc/notification-email.txt

--- a/protected/display_requests.php
+++ b/protected/display_requests.php
@@ -36,7 +36,7 @@ function process_error($msg)
 
 function get_values($row)
 {
-  global $id, $firstname, $lastname, $email, $uname, $phone, $requested, $created, $org, $title, $reason, $notes;
+  global $id, $firstname, $lastname, $email, $uname, $phone, $requested, $created, $org, $title, $reason, $notes, $expire;
 
   $id = $row['id'];
   $firstname = $row['first_name'];
@@ -56,6 +56,7 @@ function get_values($row)
     $reason = $row['reason'];
   }
   $notes = $row['notes'];
+  $expire = $row['expiration'];
 }
 
 
@@ -323,7 +324,7 @@ foreach ($rows as $row) {
 <th>Institution</th><th>Job Title</th><th>Account Reason</th>
 <th>Email Address</th><th>First Name</th><th>Last Name</th>
   <th>Phone Number</th><th>Username</th><th>Requested (UTC)</th>
-  <th>Performer</th><th>Created (UTC)</th><th>Notes</th></tr>
+  <th>Performer</th><th>Created (UTC)</th><th>Notes</th><th>Expiration</th></tr>
 </thead>
 <tbody>
 <?php
@@ -376,7 +377,7 @@ foreach ($rows as $row) {
   }
   /* Format username as link to log page */
   $uname_link = "<a href='action_log.php?uid=$uname'>$uname</a>";
-  print "<tr><td>$org</td><td>$title</td><td>$reason</td><td>$email</td><td>$firstname</td><td>$lastname</td><td>$phone</td><td>$uname_link</td><td>$requested</td><td>$performer</td><td>$created</td><td>$notes</td>";
+  print "<tr><td>$org</td><td>$title</td><td>$reason</td><td>$email</td><td>$firstname</td><td>$lastname</td><td>$phone</td><td>$uname_link</td><td>$requested</td><td>$performer</td><td>$created</td><td>$notes</td><td>$expire</td>";
   print '</tr>';
 }
 ?>

--- a/protected/geni-ar.css
+++ b/protected/geni-ar.css
@@ -170,3 +170,6 @@ th {
   -webkit-transition-timing-function: cubic-bezier(.55,0,.1,1);
   transition-timing-function: cubic-bezier(.55,0,.1,1);
 }
+input.date {
+  width: 6em;
+}

--- a/protected/tutorial_actions.php
+++ b/protected/tutorial_actions.php
@@ -55,12 +55,16 @@ if (! array_key_exists('tutexpiration', $_REQUEST)) {
   exit();
 }
 $expire = $_REQUEST['tutexpiration'];
-if (! (isset($expire) && ! is_null($expire) && $expire != "")) {
+if (! (isset($expire) && $expire != "")) {
   process_error("ERROR: Missing expiration (empty)");
   error_log("expiration: $expire");
   exit();
 }
 $desired_expire_array = date_parse($expire);
+if ($desired_expire_array === FALSE || $desired_expire_array['error_count'] > 0) {
+  process_error("ERROR: Malformed desired expiration date: " . print_r($desired_expire_array['errors'], True));
+  exit();
+}
 // If you didn't specify a time for the project expiration
 if ($desired_expire_array["hour"] == 0 and $desired_expire_array["minute"] == 0 and $desired_expire_array["second"] == 0 and $desired_expire_array["fraction"] == 0) {
   // renew for the end of the day

--- a/protected/tutorial_actions.php
+++ b/protected/tutorial_actions.php
@@ -37,7 +37,7 @@ if ($ldapconn === -1) {
 }
 
 //get request data
-$num = $_REQUEST['acctnum'];
+$num = $_REQUEST['numaccts'];
 if (!is_numeric($num)) {
   process_error("ERROR: number of accounts must be a number");
   exit();
@@ -50,11 +50,11 @@ $org_phone =  $_REQUEST['phone'];
 $desc = $_REQUEST['desc'];
 
 // expiration
-if (! array_key_exists('expiration', $_REQUEST)) {
+if (! array_key_exists('tutexpiration', $_REQUEST)) {
   process_error("ERROR: Missing expiration (no key)");
   exit();
 }
-$expire = $_REQUEST['expiration'];
+$expire = $_REQUEST['tutexpiration'];
 if (! (isset($expire) && ! is_null($expire) && $expire != "")) {
   process_error("ERROR: Missing expiration (empty)");
   error_log("expiration: $expire");

--- a/protected/tutorial_requests.php
+++ b/protected/tutorial_requests.php
@@ -24,8 +24,15 @@
 include_once('/etc/geni-ar/settings.php');
 
 global $acct_manager_url;
+require_once("header.php");
+show_header("Create GENI IdP Tutorial Accounts", array());
 
-print '<head><title>Create Tutorial Accounts</title></head>';
+// print '<head><title>Create Tutorial Accounts</title></head>';
+
+// Other styling/includes that Portal uses when using datepicker
+print "<script src='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js'></script>";
+print "<link type='text/css' href='https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/humanity/jquery-ui.css' rel='stylesheet' />";
+
 print '<a href="' . $acct_manager_url . '">Return to main page</a>';
 
 print '<h1>';
@@ -41,11 +48,22 @@ print '<p>Tutorial Description: <input type="text" name="desc" required></p>';
 print '<p>User Prefix: <input type="text" name="userprefix" required></p>';
 print '<p>Password Prefix: <input type="text" name="pwprefix" required></p>';
 print '<p>Organizer Email: <input type="email" name="email" required></p>';
-print '<p>Organizer Phone: <input type="text" name="phone" required></p>';
-print '<p>Number of Accounts: <input type="number" name="num" required></p>';
+print '<p>Organizer Phone: <input type="tel" name="phone" required></p>';
+print '<p>Number of Accounts: <input type="number" name="acctnum" required></p>';
+// Note HTML5 date type isn't honored by firefox
+print '<p>Account Expiration: <input type="date" name="expiration" required id="datepicker"></p>';
 print '<br><br>';
 print '<input type="submit" value="CREATE ACCOUNTS"/>';
 print "</form>";
-print '<form method="POST" action="index.html">';
+print '<form method="POST" action="display_requests.php">';
 print '<input type="submit" value="CANCEL"/>';
 print "</form>";
+// For datepicker, see https://api.jqueryui.com/datepicker/
+?>
+<script>
+  $(function() {
+    // minDate = 1 will not allow today or earlier, only future dates.
+      // maxDate and defaultDate are other options
+      $( "#datepicker" ).datepicker({ minDate: 1, dateFormat:'yy-mm-dd' });
+  });
+</script>

--- a/protected/tutorial_requests.php
+++ b/protected/tutorial_requests.php
@@ -49,9 +49,9 @@ print '<p>User Prefix: <input type="text" name="userprefix" required></p>';
 print '<p>Password Prefix: <input type="text" name="pwprefix" required></p>';
 print '<p>Organizer Email: <input type="email" name="email" required></p>';
 print '<p>Organizer Phone: <input type="tel" name="phone" required></p>';
-print '<p>Number of Accounts: <input type="number" name="acctnum" required></p>';
-// Note HTML5 date type isn't honored by firefox
-print '<p>Account Expiration: <input type="date" name="expiration" required id="datepicker"></p>';
+print '<p>Number of Accounts: <input type="number" name="numaccts" required></p>';
+// Note HTML5 date type isn't honored by firefox, and other browsers are inconsistent
+print '<p>Account Expiration: <input type="text" name="tutexpiration" required id="datepicker"></p>';
 print '<br><br>';
 print '<input type="submit" value="CREATE ACCOUNTS"/>';
 print "</form>";
@@ -64,6 +64,7 @@ print "</form>";
   $(function() {
     // minDate = 1 will not allow today or earlier, only future dates.
       // maxDate and defaultDate are other options
+      // yy-mm-dd makes format match HTML5 date format
       $( "#datepicker" ).datepicker({ minDate: 1, dateFormat:'yy-mm-dd' });
   });
 </script>


### PR DESCRIPTION
Add an expiration on account requests, filling it in when creating tutorial accounts.
Display this value on the tab of approved account requests.
Also clean up the formatting of the tutorial page and improve error handling.

This PR does not include any alerting on expired accounts.

Fixes issue #158 
